### PR TITLE
various things

### DIFF
--- a/GTFS.DB.PostgreSQL/Collections/PostgreSQLAgencyCollection.cs
+++ b/GTFS.DB.PostgreSQL/Collections/PostgreSQLAgencyCollection.cs
@@ -192,7 +192,7 @@ namespace GTFS.DB.PostgreSQL.Collections
             var outList = new List<string>();
             using (var command = _connection.CreateCommand())
             {
-                command.CommandText = "SELECT DISTINCT(id) FROM agency";
+                command.CommandText = "SELECT id FROM agency";
                 using (var reader = command.ExecuteReader())
                 {
                     while (reader.Read())

--- a/GTFS.DB.PostgreSQL/Collections/PostgreSQLCalendarCollection.cs
+++ b/GTFS.DB.PostgreSQL/Collections/PostgreSQLCalendarCollection.cs
@@ -286,7 +286,7 @@ namespace GTFS.DB.PostgreSQL.Collections
             var serviceIds = new List<string>();
             using (var command = _connection.CreateCommand())
             {
-                command.CommandText = "SELECT DISTINCT(service_id) FROM calendar";
+                command.CommandText = "SELECT service_id FROM calendar";
                 using (var reader = command.ExecuteReader())
                 {
                     while (reader.Read())

--- a/GTFS.DB.PostgreSQL/Collections/PostgreSQLFareRulesCollection.cs
+++ b/GTFS.DB.PostgreSQL/Collections/PostgreSQLFareRulesCollection.cs
@@ -162,6 +162,36 @@ namespace GTFS.DB.PostgreSQL.Collections
         }
 
         /// <summary>
+        /// Returns entity ids
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<string> GetIds()
+        {
+            #if DEBUG
+            var stopwatch = new System.Diagnostics.Stopwatch();
+            stopwatch.Start();
+            Console.Write($"Fetching fare ids...");
+            #endif
+            var outList = new List<string>();
+            using (var command = _connection.CreateCommand())
+            {
+                command.CommandText = "SELECT DISTINCT(fare_id) FROM fare_rule";
+                using (var reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        outList.Add(Convert.ToString(reader["fare_id"]));
+                    }
+                }
+            }
+            #if DEBUG
+            stopwatch.Stop();
+            Console.WriteLine($" {stopwatch.ElapsedMilliseconds} ms");
+            #endif
+            return outList;
+        }
+
+        /// <summary>
         /// Returns the number of entities.
         /// </summary>
         public int Count

--- a/GTFS.DB.PostgreSQL/Collections/PostgreSQLFareRulesCollection.cs
+++ b/GTFS.DB.PostgreSQL/Collections/PostgreSQLFareRulesCollection.cs
@@ -175,7 +175,7 @@ namespace GTFS.DB.PostgreSQL.Collections
             var outList = new List<string>();
             using (var command = _connection.CreateCommand())
             {
-                command.CommandText = "SELECT DISTINCT(fare_id) FROM fare_rule";
+                command.CommandText = "SELECT fare_id FROM fare_rule";
                 using (var reader = command.ExecuteReader())
                 {
                     while (reader.Read())

--- a/GTFS.DB.PostgreSQL/Collections/PostgreSQLRouteCollection.cs
+++ b/GTFS.DB.PostgreSQL/Collections/PostgreSQLRouteCollection.cs
@@ -196,6 +196,36 @@ namespace GTFS.DB.PostgreSQL.Collections
         }
 
         /// <summary>
+        /// Returns entity ids
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<string> GetIds()
+        {
+            #if DEBUG
+            var stopwatch = new System.Diagnostics.Stopwatch();
+            stopwatch.Start();
+            Console.Write($"Fetching route ids...");
+            #endif
+            var outList = new List<string>();
+            using (var command = _connection.CreateCommand())
+            {
+                command.CommandText = "SELECT DISTINCT(id) FROM route";
+                using (var reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        outList.Add(Convert.ToString(reader["id"]));
+                    }
+                }
+            }
+            #if DEBUG
+            stopwatch.Stop();
+            Console.WriteLine($" {stopwatch.ElapsedMilliseconds} ms");
+            #endif
+            return outList;
+        }
+
+        /// <summary>
         /// Returns the number of entities.
         /// </summary>
         public int Count

--- a/GTFS.DB.PostgreSQL/Collections/PostgreSQLRouteCollection.cs
+++ b/GTFS.DB.PostgreSQL/Collections/PostgreSQLRouteCollection.cs
@@ -209,7 +209,7 @@ namespace GTFS.DB.PostgreSQL.Collections
             var outList = new List<string>();
             using (var command = _connection.CreateCommand())
             {
-                command.CommandText = "SELECT DISTINCT(id) FROM route";
+                command.CommandText = "SELECT id FROM route";
                 using (var reader = command.ExecuteReader())
                 {
                     while (reader.Read())

--- a/GTFS.DB.PostgreSQL/Collections/PostgreSQLShapesCollection.cs
+++ b/GTFS.DB.PostgreSQL/Collections/PostgreSQLShapesCollection.cs
@@ -179,31 +179,41 @@ namespace GTFS.DB.PostgreSQL.Collections
             {
                 return new List<Shape>();
             }
-            var sql = new StringBuilder("SELECT id, shape_pt_lat, shape_pt_lon, shape_pt_sequence, shape_dist_traveled FROM shape WHERE FEED_ID = :feed_id AND id = :id0");
-            var parameters = new List<NpgsqlParameter>();
-            parameters.Add(new NpgsqlParameter("feed_id", DbType.Int64));
-            parameters[0].Value = _id;
-            int i = 0;
-            foreach (var entityId in entityIds)
-            {
-                if (i > 0) sql.Append($" OR id = :id{i}");
-                parameters.Add(new NpgsqlParameter($"id{i}", DbType.String));
-                parameters[1 + i].Value = entityId;
-                i++;
-            }
-            sql.Append(" ORDER BY id, shape_pt_sequence");
 
-            return new PostgreSQLEnumerable<Shape>(_connection, sql.ToString(), parameters.ToArray(), (x) =>
+            var results = new List<Shape>();
+
+            var groups = entityIds.SplitIntoGroupsByGroupIdx();
+            foreach (var group in groups)
             {
-                return new Shape()
+                var sql = new StringBuilder("SELECT id, shape_pt_lat, shape_pt_lon, shape_pt_sequence, shape_dist_traveled FROM shape WHERE FEED_ID = :feed_id AND id = :id0");
+                var parameters = new List<NpgsqlParameter>();
+                parameters.Add(new NpgsqlParameter("feed_id", DbType.Int64));
+                parameters[0].Value = _id;
+                int i = 0;
+                foreach (var entityId in group.Value)
                 {
-                    Id = x.GetString(0),
-                    Latitude = x.GetDouble(1),
-                    Longitude = x.GetDouble(2),
-                    Sequence = (uint)x.GetInt64(3),
-                    DistanceTravelled = x.IsDBNull(4) ? null : (double?)x.GetDouble(4)
-                };
-            });
+                    if (i > 0) sql.Append($" OR id = :id{i}");
+                    parameters.Add(new NpgsqlParameter($"id{i}", DbType.String));
+                    parameters[1 + i].Value = entityId;
+                    i++;
+                }
+                sql.Append(" ORDER BY id, shape_pt_sequence");
+
+                var result = new PostgreSQLEnumerable<Shape>(_connection, sql.ToString(), parameters.ToArray(), (x) =>
+                {
+                    return new Shape()
+                    {
+                        Id = x.GetString(0),
+                        Latitude = x.GetDouble(1),
+                        Longitude = x.GetDouble(2),
+                        Sequence = (uint)x.GetInt64(3),
+                        DistanceTravelled = x.IsDBNull(4) ? null : (double?)x.GetDouble(4)
+                    };
+                });
+                results.AddRange(result);
+            }
+
+            return results;
         }
 
         /// <summary>

--- a/GTFS.DB.PostgreSQL/Collections/PostgreSQLStopCollection.cs
+++ b/GTFS.DB.PostgreSQL/Collections/PostgreSQLStopCollection.cs
@@ -344,6 +344,36 @@ namespace GTFS.DB.PostgreSQL.Collections
         }
 
         /// <summary>
+        /// Returns entity ids
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<string> GetIds()
+        {
+            #if DEBUG
+            var stopwatch = new System.Diagnostics.Stopwatch();
+            stopwatch.Start();
+            Console.Write($"Fetching stop ids...");
+            #endif
+            var outList = new List<string>();
+            using (var command = _connection.CreateCommand())
+            {
+                command.CommandText = "SELECT DISTINCT(id) FROM stop";
+                using (var reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        outList.Add(Convert.ToString(reader["id"]));
+                    }
+                }
+            }
+            #if DEBUG
+            stopwatch.Stop();
+            Console.WriteLine($" {stopwatch.ElapsedMilliseconds} ms");
+            #endif
+            return outList;
+        }
+
+        /// <summary>
         /// Returns the number of entities.
         /// </summary>
         public int Count

--- a/GTFS.DB.PostgreSQL/Collections/PostgreSQLStopCollection.cs
+++ b/GTFS.DB.PostgreSQL/Collections/PostgreSQLStopCollection.cs
@@ -357,7 +357,7 @@ namespace GTFS.DB.PostgreSQL.Collections
             var outList = new List<string>();
             using (var command = _connection.CreateCommand())
             {
-                command.CommandText = "SELECT DISTINCT(id) FROM stop";
+                command.CommandText = "SELECT id FROM stop";
                 using (var reader = command.ExecuteReader())
                 {
                     while (reader.Read())

--- a/GTFS.DB.PostgreSQL/Collections/PostgreSQLTripCollection.cs
+++ b/GTFS.DB.PostgreSQL/Collections/PostgreSQLTripCollection.cs
@@ -232,7 +232,7 @@ namespace GTFS.DB.PostgreSQL.Collections
             var outList = new List<string>();
             using (var command = _connection.CreateCommand())
             {
-                command.CommandText = "SELECT DISTINCT(id) FROM trip";
+                command.CommandText = "SELECT id FROM trip";
                 using (var reader = command.ExecuteReader())
                 {
                     while (reader.Read())

--- a/GTFS.DB.PostgreSQL/Collections/PostgreSQLTripCollection.cs
+++ b/GTFS.DB.PostgreSQL/Collections/PostgreSQLTripCollection.cs
@@ -218,6 +218,36 @@ namespace GTFS.DB.PostgreSQL.Collections
             return trips;
         }
 
+        /// <summary>
+        /// Returns entity ids
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<string> GetIds()
+        {
+            #if DEBUG
+            var stopwatch = new System.Diagnostics.Stopwatch();
+            stopwatch.Start();
+            Console.Write($"Fetching trip ids...");
+            #endif
+            var outList = new List<string>();
+            using (var command = _connection.CreateCommand())
+            {
+                command.CommandText = "SELECT DISTINCT(id) FROM trip";
+                using (var reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        outList.Add(Convert.ToString(reader["id"]));
+                    }
+                }
+            }
+            #if DEBUG
+            stopwatch.Stop();
+            Console.WriteLine($" {stopwatch.ElapsedMilliseconds} ms");
+            #endif
+            return outList;
+        }
+
         public int Count
         {
             get { throw new NotImplementedException(); }

--- a/GTFS.DB.SQLite/Collections/SQLiteAgencyCollection.cs
+++ b/GTFS.DB.SQLite/Collections/SQLiteAgencyCollection.cs
@@ -205,7 +205,7 @@ namespace GTFS.DB.SQLite.Collections
             var outList = new List<string>();
             using (var command = _connection.CreateCommand())
             {
-                command.CommandText = "SELECT DISTINCT(id) FROM agency";
+                command.CommandText = "SELECT id FROM agency";
                 using (var reader = command.ExecuteReader())
                 {
                     while (reader.Read())

--- a/GTFS.DB.SQLite/Collections/SQLiteAgencyCollection.cs
+++ b/GTFS.DB.SQLite/Collections/SQLiteAgencyCollection.cs
@@ -197,6 +197,27 @@ namespace GTFS.DB.SQLite.Collections
         }
 
         /// <summary>
+        /// Returns entity ids
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<string> GetIds()
+        {
+            var outList = new List<string>();
+            using (var command = _connection.CreateCommand())
+            {
+                command.CommandText = "SELECT DISTINCT(id) FROM agency";
+                using (var reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        outList.Add(Convert.ToString(reader["id"]));
+                    }
+                }
+            }
+            return outList;
+        }
+
+        /// <summary>
         /// Returns the number of entities.
         /// </summary>
         public int Count

--- a/GTFS.DB.SQLite/Collections/SQLiteCalendarCollection.cs
+++ b/GTFS.DB.SQLite/Collections/SQLiteCalendarCollection.cs
@@ -302,7 +302,7 @@ namespace GTFS.DB.SQLite.Collections
             var serviceIds = new List<string>();
             using (var command = _connection.CreateCommand())
             {
-                command.CommandText = "SELECT DISTINCT(service_id) FROM calendar";
+                command.CommandText = "SELECT service_id FROM calendar";
                 using (var reader = command.ExecuteReader())
                 {
                     while (reader.Read())

--- a/GTFS.DB.SQLite/Collections/SQLiteFareRulesCollection.cs
+++ b/GTFS.DB.SQLite/Collections/SQLiteFareRulesCollection.cs
@@ -159,7 +159,7 @@ namespace GTFS.DB.SQLite.Collections
             var outList = new List<string>();
             using (var command = _connection.CreateCommand())
             {
-                command.CommandText = "SELECT DISTINCT(fare_id) FROM fare_rule";
+                command.CommandText = "SELECT fare_id FROM fare_rule";
                 using (var reader = command.ExecuteReader())
                 {
                     while (reader.Read())

--- a/GTFS.DB.SQLite/Collections/SQLiteFareRulesCollection.cs
+++ b/GTFS.DB.SQLite/Collections/SQLiteFareRulesCollection.cs
@@ -151,6 +151,27 @@ namespace GTFS.DB.SQLite.Collections
         }
 
         /// <summary>
+        /// Returns entity ids
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<string> GetIds()
+        {
+            var outList = new List<string>();
+            using (var command = _connection.CreateCommand())
+            {
+                command.CommandText = "SELECT DISTINCT(fare_id) FROM fare_rule";
+                using (var reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        outList.Add(Convert.ToString(reader["fare_id"]));
+                    }
+                }
+            }
+            return outList;
+        }
+
+        /// <summary>
         /// Returns the number of entities.
         /// </summary>
         public int Count

--- a/GTFS.DB.SQLite/Collections/SQLiteRouteCollection.cs
+++ b/GTFS.DB.SQLite/Collections/SQLiteRouteCollection.cs
@@ -202,6 +202,27 @@ namespace GTFS.DB.SQLite.Collections
         }
 
         /// <summary>
+        /// Returns entity ids
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<string> GetIds()
+        {
+            var outList = new List<string>();
+            using (var command = _connection.CreateCommand())
+            {
+                command.CommandText = "SELECT DISTINCT(id) FROM route";
+                using (var reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        outList.Add(Convert.ToString(reader["id"]));
+                    }
+                }
+            }
+            return outList;
+        }
+
+        /// <summary>
         /// Returns the number of entities.
         /// </summary>
         public int Count

--- a/GTFS.DB.SQLite/Collections/SQLiteRouteCollection.cs
+++ b/GTFS.DB.SQLite/Collections/SQLiteRouteCollection.cs
@@ -210,7 +210,7 @@ namespace GTFS.DB.SQLite.Collections
             var outList = new List<string>();
             using (var command = _connection.CreateCommand())
             {
-                command.CommandText = "SELECT DISTINCT(id) FROM route";
+                command.CommandText = "SELECT id FROM route";
                 using (var reader = command.ExecuteReader())
                 {
                     while (reader.Read())

--- a/GTFS.DB.SQLite/Collections/SQLiteStopCollection.cs
+++ b/GTFS.DB.SQLite/Collections/SQLiteStopCollection.cs
@@ -348,6 +348,27 @@ namespace GTFS.DB.SQLite.Collections
         }
 
         /// <summary>
+        /// Returns entity ids
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<string> GetIds()
+        {
+            var outList = new List<string>();
+            using (var command = _connection.CreateCommand())
+            {
+                command.CommandText = "SELECT DISTINCT(id) FROM stop";
+                using (var reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        outList.Add(Convert.ToString(reader["id"]));
+                    }
+                }
+            }
+            return outList;
+        }
+
+        /// <summary>
         /// Returns the number of entities.
         /// </summary>
         public int Count

--- a/GTFS.DB.SQLite/Collections/SQLiteStopCollection.cs
+++ b/GTFS.DB.SQLite/Collections/SQLiteStopCollection.cs
@@ -356,7 +356,7 @@ namespace GTFS.DB.SQLite.Collections
             var outList = new List<string>();
             using (var command = _connection.CreateCommand())
             {
-                command.CommandText = "SELECT DISTINCT(id) FROM stop";
+                command.CommandText = "SELECT id FROM stop";
                 using (var reader = command.ExecuteReader())
                 {
                     while (reader.Read())

--- a/GTFS.DB.SQLite/Collections/SQLiteStopTimeCollection.cs
+++ b/GTFS.DB.SQLite/Collections/SQLiteStopTimeCollection.cs
@@ -339,36 +339,46 @@ namespace GTFS.DB.SQLite.Collections
             {
                 return new List<StopTime>();
             }
-            var sql = new StringBuilder("SELECT trip_id, arrival_time, departure_time, stop_id, stop_sequence, stop_headsign, pickup_type, drop_off_type, shape_dist_traveled, passenger_boarding, passenger_alighting FROM stop_time WHERE FEED_ID = :feed_id AND trip_id = :trip_id0");
-            var parameters = new List<SQLiteParameter>();
-            parameters.Add(new SQLiteParameter("feed_id", DbType.Int64));
-            parameters[0].Value = _id;
-            int i = 0;
-            foreach (var tripId in tripIds)
+
+            var results = new List<StopTime>();
+
+            var groups = tripIds.SplitIntoGroupsByGroupIdx();
+            foreach (var group in groups)
             {
-                if (i > 0) sql.Append($" OR trip_id = :trip_id{i}");
-                parameters.Add(new SQLiteParameter($"trip_id{i}", DbType.String));
-                parameters[1 + i].Value = tripId;
-                i++;
+                var sql = new StringBuilder("SELECT trip_id, arrival_time, departure_time, stop_id, stop_sequence, stop_headsign, pickup_type, drop_off_type, shape_dist_traveled, passenger_boarding, passenger_alighting FROM stop_time WHERE FEED_ID = :feed_id AND trip_id = :trip_id0");
+                var parameters = new List<SQLiteParameter>();
+                parameters.Add(new SQLiteParameter("feed_id", DbType.Int64));
+                parameters[0].Value = _id;
+                int i = 0;
+                foreach (var tripId in group.Value)
+                {
+                    if (i > 0) sql.Append($" OR trip_id = :trip_id{i}");
+                    parameters.Add(new SQLiteParameter($"trip_id{i}", DbType.String));
+                    parameters[1 + i].Value = tripId;
+                    i++;
+                }
+
+                var result = new SQLiteEnumerable<StopTime>(_connection, sql.ToString(), parameters.ToArray(), (x) =>
+                {
+                    return new StopTime()
+                    {
+                        TripId = x.GetString(0),
+                        ArrivalTime = TimeOfDay.FromTotalSeconds(x.GetInt32(1)),
+                        DepartureTime = TimeOfDay.FromTotalSeconds(x.GetInt32(2)),
+                        StopId = x.GetString(3),
+                        StopSequence = (uint)x.GetInt32(4),
+                        StopHeadsign = x.IsDBNull(5) ? null : x.GetString(5),
+                        PickupType = x.IsDBNull(6) ? null : (PickupType?)x.GetInt64(6),
+                        DropOffType = x.IsDBNull(7) ? null : (DropOffType?)x.GetInt64(7),
+                        ShapeDistTravelled = x.IsDBNull(8) ? null : x.GetString(8),
+                        PassengerBoarding = x.IsDBNull(9) ? null : (int?)x.GetInt32(9),
+                        PassengerAlighting = x.IsDBNull(10) ? null : (int?)x.GetInt32(10)
+                    };
+                });
+                results.AddRange(result);
             }
 
-            return new SQLiteEnumerable<StopTime>(_connection, sql.ToString(), parameters.ToArray(), (x) =>
-            {
-                return new StopTime()
-                {
-                    TripId = x.GetString(0),
-                    ArrivalTime = TimeOfDay.FromTotalSeconds(x.GetInt32(1)),
-                    DepartureTime = TimeOfDay.FromTotalSeconds(x.GetInt32(2)),
-                    StopId = x.GetString(3),
-                    StopSequence = (uint)x.GetInt32(4),
-                    StopHeadsign = x.IsDBNull(5) ? null : x.GetString(5),
-                    PickupType = x.IsDBNull(6) ? null : (PickupType?)x.GetInt64(6),
-                    DropOffType = x.IsDBNull(7) ? null : (DropOffType?)x.GetInt64(7),
-                    ShapeDistTravelled = x.IsDBNull(8) ? null : x.GetString(8),
-                    PassengerBoarding = x.IsDBNull(9) ? null : (int?)x.GetInt32(9),
-                    PassengerAlighting = x.IsDBNull(10) ? null : (int?)x.GetInt32(10)
-                };
-            });
+            return results;
         }
 
         /// <summary>

--- a/GTFS.DB.SQLite/Collections/SQLiteTripCollection.cs
+++ b/GTFS.DB.SQLite/Collections/SQLiteTripCollection.cs
@@ -223,6 +223,27 @@ namespace GTFS.DB.SQLite.Collections
             });
         }
 
+        /// <summary>
+        /// Returns entity ids
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<string> GetIds()
+        {
+            var outList = new List<string>();
+            using (var command = _connection.CreateCommand())
+            {
+                command.CommandText = "SELECT DISTINCT(id) FROM trip";
+                using (var reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        outList.Add(Convert.ToString(reader["id"]));
+                    }
+                }
+            }
+            return outList;
+        }
+
         public int Count
         {
             get { throw new NotImplementedException(); }

--- a/GTFS.DB.SQLite/Collections/SQLiteTripCollection.cs
+++ b/GTFS.DB.SQLite/Collections/SQLiteTripCollection.cs
@@ -232,7 +232,7 @@ namespace GTFS.DB.SQLite.Collections
             var outList = new List<string>();
             using (var command = _connection.CreateCommand())
             {
-                command.CommandText = "SELECT DISTINCT(id) FROM trip";
+                command.CommandText = "SELECT id FROM trip";
                 using (var reader = command.ExecuteReader())
                 {
                     while (reader.Read())

--- a/GTFS/Entities/Collections/IUniqueEntityCollection.cs
+++ b/GTFS/Entities/Collections/IUniqueEntityCollection.cs
@@ -89,6 +89,12 @@ namespace GTFS.Entities.Collections
         IEnumerable<T> Get();
 
         /// <summary>
+        /// Returns all entity ids.
+        /// </summary>
+        /// <returns></returns>
+        IEnumerable<string> GetIds();
+
+        /// <summary>
         /// Returns the number of entities.
         /// </summary>
         int Count

--- a/GTFS/Entities/Collections/UniqueEntityListCollection.cs
+++ b/GTFS/Entities/Collections/UniqueEntityListCollection.cs
@@ -117,6 +117,11 @@ namespace GTFS.Entities.Collections
             return _entities;
         }
 
+        public IEnumerable<string> GetIds()
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Returns the number of entities.
         /// </summary>

--- a/GTFS/Extensions.cs
+++ b/GTFS/Extensions.cs
@@ -24,6 +24,7 @@ using GTFS.Entities.Collections;
 using System;
 using System.Linq;
 using System.Diagnostics;
+using System.Collections.Generic;
 
 namespace GTFS
 {
@@ -326,6 +327,30 @@ namespace GTFS
             {
                 throw new ArgumentOutOfRangeException("value", string.Format("The given string can is not a hex-color: {0}.", value));
             }
+        }
+
+        public static Dictionary<int, List<T>> SplitIntoGroupsByGroupIdx<T>(this IEnumerable<T> _self, int maxGroupCount = 900)
+        {
+            var dict = new Dictionary<int, List<T>>();
+            int groupIdx = 0;
+            int numElementsInCurrentGroup = 0;
+            foreach (var item in _self)
+            {
+                if (numElementsInCurrentGroup == maxGroupCount)
+                {
+                    groupIdx++;
+                    numElementsInCurrentGroup = 0;
+                }
+
+                if (!dict.ContainsKey(groupIdx))
+                {
+                    dict.Add(groupIdx, new List<T>());
+                }
+                dict[groupIdx].Add(item);
+                numElementsInCurrentGroup++;
+            }
+
+            return dict;
         }
     }
 }


### PR DESCRIPTION
 - more getids methods - probably included in the last Cap release by accident
 - fixed the sql params limit reached bug by splitting the request into groups of just under 1000 entities
 - ordering the stoptimes responses from postgres